### PR TITLE
WA-113424

### DIFF
--- a/README.md
+++ b/README.md
@@ -1204,7 +1204,50 @@ For more information about these configurable parameters, see the **[Server para
 		#service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 		#networking.gke.io/load-balancer-type: "Internal"
 
-		
+### Enabling communication from a Kubernetes agents without using certificates 
+
+If you want to install the agents without using certificates and also enable communication with the server through the JWT Token, add a secret with the engine credentials. This applies if the agent is connected to a distributed server. Also ensure to enable the enableJWT parameter in the agent configuration section.
+Ensure the following parameters are set in the secret: 
+
+**WA_USER_ENGINE**
+
+**WA_USER_ENGINE_PASSWORD**
+
+Where
+
+**WA_USER_ENGINE** is the engine user encoded in base64 encoding
+
+**WA_USER_ENGINE_PASSWORD** is the engine password encoded in base64 encoding
+
+Ensure the name of the secret is  < namespace >-waagent-secret.
+
+See the following example:
+
+		apiVersion: v1 
+		kind: Secret 
+		metadata: 
+		  name: <namespace>-waagent-secret
+		  namespace: <namespace>
+		type: "Opaque"
+		data:  
+  		  WA_USER_ENGINE: <engineUserBase64>
+  		  WA_USER_ENGINE_PASSWORD: <engineUserPasswordBase64>
+		  
+As an alternative to specifying username and password, you can create a new secret named < namespace >-waagent-secret adding the **WA_API_KEY**  parameter. Ensure you specify a  valid API key as value of the parameter. 
+
+See the following example:
+
+		apiVersion: v1 
+	        kind: Secret 
+	        metadata: 
+	          name: <namespace>-waagent-secret
+	          namespace: <namespace>
+	        type: "Opaque"
+	        data:  
+	          WA_API_KEY: <validApiKey> 
+
+
+				
 
 		
 ### Enabling communication between product components in an on-premises offering with components in the Cloud


### PR DESCRIPTION
Added the WA_API_KEY variable with an example to the Enabling communication from a Kubernetes agents without using certificates section.